### PR TITLE
Fixed warning if self::$cache['path'] is not set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+*~
+vendor/
 /cache/

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -141,7 +141,7 @@ class Cache
     public static function getCachePath()
     {
         // cache path not defined
-        if (self::$cache['path'] == null) {
+        if (!isset(self::$cache['path'])) {
             // redefine cache path to default path
             self::setCachePath($_SERVER['DOCUMENT_ROOT'] . '/cache/');
         }


### PR DESCRIPTION
I fixed a small issue I found. If the `path` index of the `Cache::$cache` property was not set on line 144, a warning like the following was generated:
`Undefined index: path in /home/manolis/repos/cache/src/Cache.php on line 144`
